### PR TITLE
Add postgres SSL support configuration

### DIFF
--- a/content/4.backend/2.configuration.md
+++ b/content/4.backend/2.configuration.md
@@ -91,6 +91,11 @@ Log all postgres queries in the console, this outputs sensitive data so DO NOT r
 
 Example: `false`
 
+### `postgres.ssl`
+Enable SSL support for postgres connections.
+
+Example: `true`
+
 ### `crypto.sessionSecret` - REQUIRED
 The secret used to sign sessions. Must be at least 32 characters long.
 


### PR DESCRIPTION
Adds documentation for the new config option added in [#29](https://github.com/movie-web/backend/pull/28).

![image](https://github.com/movie-web/docs/assets/72168435/88a1d646-96e0-4649-a1de-119b6b90a76c)

![200w](https://github.com/movie-web/docs/assets/72168435/9e6c3e25-471e-4164-8cfa-a82d9e15be41)
