### PR TITLE
Fix invalid links in client configuration page

### DIFF
--- a/content/3.client/3.configuration.md
+++ b/content/3.client/3.configuration.md
@@ -28,7 +28,7 @@ window.__CONFIG__ = {
 
 ### `VITE_TMDB_READ_API_KEY` - REQUIRED
 
-This is the **read** API key from TMDB to allow movie-web to search for media. [Get one by following our guide](/self-hosting/client#tmdb-api-key).
+This is the **read** API key from TMDB to allow movie-web to search for media. [Get one by following our guide](/client/tmdb).
 
 ::alert{type="warning"}
 :icon{name="material-symbols:warning-rounded"} The example will not work for you, get your own
@@ -37,7 +37,7 @@ Example: <code style="overflow-wrap: anywhere">VITE_TMDB_READ_API_KEY=eyJhbGciOi
 
 ### `VITE_CORS_PROXY_URL` - REQUIRED
 
-This is where you put proxy URLS, you must have at least one. [Get one by following our guide](/self-hosting/proxy#cloudflare-workers).
+This is where you put proxy URLS, you must have at least one. [Get one by following our guide](/proxy/deploy).
 
 You can add multiple workers by separating them by a comma, they will be load balanced using round robin method on the client.
 


### PR DESCRIPTION
The "Get one by following our guide" links for `VITE_TMDB_READ_API_KEY` and `VITE_CORS_PROXY_URL` now brings to 404 Not Found. The correct link should be https://docs.movie-web.app/client/tmdb and https://docs.movie-web.app/proxy/deploy respectively.

![image](https://github.com/movie-web/docs/assets/20135478/6a1034e6-8c20-4a7e-aedd-db6f31569288)

![image](https://github.com/movie-web/docs/assets/20135478/61a95946-8139-4b68-9400-408108ee91bc)

![image](https://github.com/movie-web/docs/assets/20135478/5d7addcd-c8e6-473a-b4e8-7261a1d68314)
