### PR TITLE
Add `VITE_GA_ID` and update proxy docs to mention new behaviour.

### DIFF
--- a/content/3.client/3.configuration.md
+++ b/content/3.client/3.configuration.md
@@ -42,13 +42,15 @@ This is the **read** API key from TMDB to allow movie-web to search for media. [
 **Required. The client will not work properly if this is not configured.**
 ::
 
-### `VITE_CORS_PROXY_URL` ⚠
+### `VITE_CORS_PROXY_URL`
 
 - Type: `string`
 - Default: `""`
 - Example: `"https://example1.example.com,https://example2.example.com"`
 
-This is where you put proxy URLS, you must have at least one. [Get one by following our guide](/proxy/deploy).
+This is where you put proxy URLs. [Get some by following our guides](/proxy/deploy).
+
+If left empty, the client onboarding will not provide a "default setup" and the user will have to manually configure their own proxy or use the extension.
 
 You can add multiple Workers by separating them with a comma, they will be load balanced using round robin method on the client.
 **Worker URL entries must not end with a slash.**
@@ -80,7 +82,7 @@ Setting this configuration value to `true` will enable the history-router.
 ### `VITE_BACKEND_URL`
 
 - Type: `string`
-- Default: `"https://backend.movie-web.app"`
+- Default: `""`
 - Example: `"https://backend.example.com"`
 
 This is the URL for the movie-web backend server which handles cross-device syncing.
@@ -174,6 +176,14 @@ A PWA web application can be installed as an application to your phone or deskto
 ::alert{type="warning"}
 Make sure you know what you're doing before enabling this, it **cannot be disabled** after you've set it up once.
 ::
+
+### `VITE_GA_ID`
+
+- Type: `string`
+- Default: `""`
+- Example: `"G-1234567890"`
+
+The Google Analytics ID for tracking user behavior. If omitted, no tracking will be done.
 
 ### `VITE_APP_DOMAIN`
 


### PR DESCRIPTION
Adds the `VITE_GA_ID` environment variable, updates proxy documentation since we now allow for no proxy URLs to be set.