### PR TITLE
Recommend Netlify instead of Cloudflare

### DIFF
--- a/content/2.proxy/0.introduction.md
+++ b/content/2.proxy/0.introduction.md
@@ -8,4 +8,4 @@ Our proxy is used to bypass CORS-protected URLs on the client side, allowing use
 
 The proxy is made using [Nitro by UnJS](https://nitro.unjs.io/) which supports building the proxy to work on multiple providers including Cloudflare Workers, AWS Lambda and [more...](https://nitro.unjs.io/deploy)
 
-Our recommended provider is Cloudflare due to its [generous free plan](https://www.cloudflare.com/en-gb/plans/developer-platform/).
+Our recommended provider is Netlify due to its [generous free plan](https://www.netlify.com/pricing/#core-pricing-table).


### PR DESCRIPTION
Since showbox blacklisted CloudFlare IPs, the preferred method for hosting a proxy is now Netlify.