### PR TITLE
updated deploy.md to include a more step by step guide for selfhosting

### DIFF
--- a/content/4.backend/1.deploy.md
+++ b/content/4.backend/1.deploy.md
@@ -20,6 +20,8 @@ The command below will not work unless customized by you, change the [`MWB_POSTG
 
 If you're using a hosted postgres database like [Neon](https://neon.tech/){target="\_blank"}, you'll also want to enable SSL support for the backend using the [`postgres.ssl`](2.configuration.md#postgresssl) option.
 
+For a more in-depth guide, take a look at the community-created guide by Pokey: [Backend Deployment Guide](https://rentry.co/Movie-Web-Backend)
+
 For other versions of the image, [check out the package page](https://github.com/movie-web/backend/pkgs/container/backend){target="\_blank"}.
 
 ```sh
@@ -32,6 +34,7 @@ docker run \
 ```
 
 After running that command, your backend [_should_](../1.self-hosting/4.troubleshooting.md) now be available on `localhost:80`. if you want to be able to connect to the backend outside of your local network (for example sharing it with your friends), then you'll need set up to port forwarding.
+
 
 ## Method 2 - Railway (Easy)
 


### PR DESCRIPTION
Made a guide while I was setting up backend for selfhosting, would maybe motivate more people to selfhost and we can have more public instances. As well just a QoL for people not familiar too much with docker.