### PR TITLE
docs: move community instances above recommended backend

### DIFF
--- a/content/0.instances.md
+++ b/content/0.instances.md
@@ -7,13 +7,6 @@ icon: 'mdi:web'
 
 This page showcases movie-web instances hosted by the community and other alternative sites. If you want to add your instance to this list, please open a pull request on [GitHub](https://github.com/movie-web/docs).
 
-## Recommended Community Backend
-
-To keep consistency and compatibility between different instances our partner, [lonelil](https://github.com/lonelil), has kindly offered to host a movie-web backend with a copy of the original data from the now unavailable movie-web.app backend. You can access this backend at: `https://mw-backend.lonelil.com` and `https://mw-backend.lonelil.ru`
-Meaning users **do not** have to set up a new account; you can use your previous passphrase from movie-web, and all of your data will be there!
-
-You **do not** have to set up a new account; you can use your previous passphrase from movie-web, and all of your data will be there!
-
 ## Community Instances
 
 The community maintains these trusted instances, meaning they are likely to be up-to-date. Remember that since these are volunteer instances, they might be down or stop working at any time. If you want to be sure you have access to movie-web, consider [hosting your own instance](../1.self-hosting/1.hosting-intro.md). 
@@ -31,6 +24,13 @@ The community maintains these trusted instances, meaning they are likely to be u
 - [movie-web.x](https://movie-web.x) via [Unstoppable Domains](https://unstoppabledomains.com) and [IPFS](https://ipfs.tech) » 💾🌐
     - [movie-web.x](https://movie-web.x) is only accessible using Brave, Opera or installing an [extension](https://unstoppabledomains.com/extension) to resolve unstoppable domains
     - If you cannot access https://movie-web.x try using a gateway: [Cloudflare](https://cloudflare-ipfs.com/ipns/k51qzi5uqu5diql6nkzokwdvz9511dp9itillc7xhixptq14tk1oz8agh3wrjd), [dweb.link](https://k51qzi5uqu5diql6nkzokwdvz9511dp9itillc7xhixptq14tk1oz8agh3wrjd.ipns.dweb.link), [cf-ipfs](https://k51qzi5uqu5diql6nkzokwdvz9511dp9itillc7xhixptq14tk1oz8agh3wrjd.ipns.cf-ipfs.com)
+
+## Recommended Community Backend
+
+To keep consistency and compatibility between different instances our partner, [lonelil](https://github.com/lonelil), has kindly offered to host a movie-web backend with a copy of the original data from the now unavailable movie-web.app backend. You can access this backend at: `https://mw-backend.lonelil.com` and `https://mw-backend.lonelil.ru`
+Meaning users **do not** have to set up a new account; you can use your previous passphrase from movie-web, and all of your data will be there!
+
+You **do not** have to set up a new account; you can use your previous passphrase from movie-web, and all of your data will be there!
 
 ## Alternatives
 


### PR DESCRIPTION
Most users using these users are end-users and shouldn't really care what the backend is; more valuable to show them the instances first in my opinion